### PR TITLE
(account/create) 계좌 생성 API 추가 및 머지 후 누락 파일 추가/수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1887,6 +1887,14 @@
         "reflect-metadata": "^0.1.13"
       }
     },
+    "node_modules/@nestjs/config/node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@nestjs/core": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.3.0.tgz",
@@ -2088,18 +2096,6 @@
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.2.0",
         "typeorm": "^0.3.0"
-      }
-    },
-    "node_modules/@nestjs/typeorm/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -9614,9 +9610,13 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
         "uuid": "dist/bin/uuid"
       }

--- a/src/accounts/accounts.controller.ts
+++ b/src/accounts/accounts.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { AccountsService } from './accounts.service';
+import { CreateAccountDto } from './dto/create-account.dto';
+import { UpdateAccountDto } from './dto/update-account.dto';
+
+@Controller('accounts')
+export class AccountsController {
+  constructor(private readonly accountsService: AccountsService) {}
+
+  @Post()
+  create(@Body() createAccountDto: CreateAccountDto) {
+    return this.accountsService.create(createAccountDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.accountsService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.accountsService.findOne(+id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() updateAccountDto: UpdateAccountDto) {
+    return this.accountsService.update(+id, updateAccountDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.accountsService.remove(+id);
+  }
+}

--- a/src/accounts/accounts.controller.ts
+++ b/src/accounts/accounts.controller.ts
@@ -9,6 +9,11 @@ import { ApiTags } from "@nestjs/swagger";
 export class AccountsController {
   constructor(private readonly accountsService: AccountsService) {}
 
+  /**
+   * 계좌 생성하기
+   * @param name
+   * @returns
+   */
   @Post()
   async create(@Body() { name }: CreateAccountDto) {
     await this.accountsService.createNewAccount(name, 1); // 로그인 기능 개발되면 유저 Id는 데코레이터 활용 예정

--- a/src/accounts/accounts.controller.ts
+++ b/src/accounts/accounts.controller.ts
@@ -1,15 +1,21 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
-import { AccountsService } from './accounts.service';
-import { CreateAccountDto } from './dto/create-account.dto';
-import { UpdateAccountDto } from './dto/update-account.dto';
+import { Controller, Get, Post, Body, Patch, Param, Delete } from "@nestjs/common";
+import { AccountsService } from "./accounts.service";
+import { CreateAccountDto } from "./dto/create-account.dto";
+import { UpdateAccountDto } from "./dto/update-account.dto";
+import { ApiTags } from "@nestjs/swagger";
 
-@Controller('accounts')
+@ApiTags("Accounts")
+@Controller("accounts")
 export class AccountsController {
   constructor(private readonly accountsService: AccountsService) {}
 
   @Post()
-  create(@Body() createAccountDto: CreateAccountDto) {
-    return this.accountsService.create(createAccountDto);
+  async create(@Body() { name }: CreateAccountDto) {
+    await this.accountsService.createNewAccount(name, 1); // 로그인 기능 개발되면 유저 Id는 데코레이터 활용 예정
+    return {
+      success: true,
+      message: "okay"
+    };
   }
 
   @Get()
@@ -17,18 +23,18 @@ export class AccountsController {
     return this.accountsService.findAll();
   }
 
-  @Get(':id')
-  findOne(@Param('id') id: string) {
+  @Get(":id")
+  findOne(@Param("id") id: string) {
     return this.accountsService.findOne(+id);
   }
 
-  @Patch(':id')
-  update(@Param('id') id: string, @Body() updateAccountDto: UpdateAccountDto) {
+  @Patch(":id")
+  update(@Param("id") id: string, @Body() updateAccountDto: UpdateAccountDto) {
     return this.accountsService.update(+id, updateAccountDto);
   }
 
-  @Delete(':id')
-  remove(@Param('id') id: string) {
+  @Delete(":id")
+  remove(@Param("id") id: string) {
     return this.accountsService.remove(+id);
   }
 }

--- a/src/accounts/accounts.module.ts
+++ b/src/accounts/accounts.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { AccountsService } from './accounts.service';
+import { AccountsController } from './accounts.controller';
+
+@Module({
+  controllers: [AccountsController],
+  providers: [AccountsService],
+})
+export class AccountsModule {}

--- a/src/accounts/accounts.module.ts
+++ b/src/accounts/accounts.module.ts
@@ -3,9 +3,10 @@ import { AccountsService } from "./accounts.service";
 import { AccountsController } from "./accounts.controller";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { Account } from "./entities/account.entity";
+import { User } from "src/user/entities/user.entity";
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Account])],
+  imports: [TypeOrmModule.forFeature([Account, User])],
   controllers: [AccountsController],
   providers: [AccountsService]
 })

--- a/src/accounts/accounts.module.ts
+++ b/src/accounts/accounts.module.ts
@@ -1,9 +1,12 @@
-import { Module } from '@nestjs/common';
-import { AccountsService } from './accounts.service';
-import { AccountsController } from './accounts.controller';
+import { Module } from "@nestjs/common";
+import { AccountsService } from "./accounts.service";
+import { AccountsController } from "./accounts.controller";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { Account } from "./entities/account.entity";
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Account])],
   controllers: [AccountsController],
-  providers: [AccountsService],
+  providers: [AccountsService]
 })
 export class AccountsModule {}

--- a/src/accounts/accounts.service.ts
+++ b/src/accounts/accounts.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { CreateAccountDto } from './dto/create-account.dto';
+import { UpdateAccountDto } from './dto/update-account.dto';
+
+@Injectable()
+export class AccountsService {
+  create(createAccountDto: CreateAccountDto) {
+    return 'This action adds a new account';
+  }
+
+  findAll() {
+    return `This action returns all accounts`;
+  }
+
+  findOne(id: number) {
+    return `This action returns a #${id} account`;
+  }
+
+  update(id: number, updateAccountDto: UpdateAccountDto) {
+    return `This action updates a #${id} account`;
+  }
+
+  remove(id: number) {
+    return `This action removes a #${id} account`;
+  }
+}

--- a/src/accounts/accounts.service.ts
+++ b/src/accounts/accounts.service.ts
@@ -1,11 +1,23 @@
-import { Injectable } from '@nestjs/common';
-import { CreateAccountDto } from './dto/create-account.dto';
-import { UpdateAccountDto } from './dto/update-account.dto';
+import { Injectable } from "@nestjs/common";
+import { CreateAccountDto } from "./dto/create-account.dto";
+import { UpdateAccountDto } from "./dto/update-account.dto";
+import { v4 as uuidv4 } from "uuid";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Account } from "./entities/account.entity";
+import { Repository } from "typeorm";
 
 @Injectable()
 export class AccountsService {
-  create(createAccountDto: CreateAccountDto) {
-    return 'This action adds a new account';
+  constructor(
+    @InjectRepository(Account)
+    private readonly accountRepository: Repository<Account>
+  ) {}
+
+  async createNewAccount(name: string, userId: number) {
+    await this.accountRepository.save({
+      name,
+      userId
+    });
   }
 
   findAll() {
@@ -22,5 +34,12 @@ export class AccountsService {
 
   remove(id: number) {
     return `This action removes a #${id} account`;
+  }
+
+  generateUniqueAccountNumber() {
+    const uniqueId = uuidv4();
+    const formattedAccountId = uniqueId.replace(/-/g, "").substring(0, 9);
+    const accountNumber = `${formattedAccountId.slice(0, 3)}-${formattedAccountId.slice(3, 6)}-${formattedAccountId.slice(6)}`;
+    return accountNumber;
   }
 }

--- a/src/accounts/dto/create-account.dto.ts
+++ b/src/accounts/dto/create-account.dto.ts
@@ -1,0 +1,4 @@
+import { PickType } from "@nestjs/swagger";
+import { Account } from "../entities/account.entity";
+
+export class CreateAccountDto extends PickType(Account, ["name"]) {}

--- a/src/accounts/dto/update-account.dto.ts
+++ b/src/accounts/dto/update-account.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateAccountDto } from './create-account.dto';
+
+export class UpdateAccountDto extends PartialType(CreateAccountDto) {}

--- a/src/accounts/entities/account.entity.ts
+++ b/src/accounts/entities/account.entity.ts
@@ -1,12 +1,10 @@
 import { IsNotEmpty, IsString } from "class-validator";
 import { BaseEntity } from "src/common/entities/base.entity";
-import { Column, Entity } from "typeorm";
+import { User } from "src/user/entities/user.entity";
+import { Column, Entity, JoinColumn, ManyToOne } from "typeorm";
 
-@Entity()
+@Entity({ name: "accounts" })
 export class Account extends BaseEntity {
-  @Column({ nullable: false }) // 유저 Entity 추가 후 관계 설정 예정
-  userId: number;
-
   /**
    * 계좌이름
    * @example "2차 전지"
@@ -19,4 +17,8 @@ export class Account extends BaseEntity {
 
   @Column({ default: 100000000 })
   point: number;
+
+  @ManyToOne(() => User, (user) => user.account)
+  @JoinColumn({ name: "user_id" })
+  user: User;
 }

--- a/src/accounts/entities/account.entity.ts
+++ b/src/accounts/entities/account.entity.ts
@@ -1,14 +1,11 @@
 import { IsNotEmpty, IsString } from "class-validator";
 import { BaseEntity } from "src/common/entities/base.entity";
-import { Column, Entity, PrimaryGeneratedColumn } from "typeorm";
+import { Column, Entity } from "typeorm";
 
 @Entity()
 export class Account extends BaseEntity {
-  @PrimaryGeneratedColumn()
-  id: number;
-
-  @Column({ nullable: false })
-  accountNum: string;
+  @Column({ nullable: false }) // 유저 Entity 추가 후 관계 설정 예정
+  userId: number;
 
   /**
    * 계좌이름

--- a/src/accounts/entities/account.entity.ts
+++ b/src/accounts/entities/account.entity.ts
@@ -1,0 +1,25 @@
+import { IsNotEmpty, IsString } from "class-validator";
+import { BaseEntity } from "src/common/entities/base.entity";
+import { Column, Entity, PrimaryGeneratedColumn } from "typeorm";
+
+@Entity()
+export class Account extends BaseEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ nullable: false })
+  accountNum: string;
+
+  /**
+   * 계좌이름
+   * @example "2차 전지"
+   * @requires true
+   */
+  @IsString()
+  @IsNotEmpty({ message: "계좌 이름을 지정해주세요." })
+  @Column({ nullable: false })
+  name: string;
+
+  @Column({ default: 100000000 })
+  point: number;
+}

--- a/src/accounts/test/accounts.controller.spec.ts
+++ b/src/accounts/test/accounts.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { AccountsController } from "../accounts.controller";
+import { AccountsService } from "../accounts.service";
+
+describe("AccountsController", () => {
+  let controller: AccountsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AccountsController],
+      providers: [AccountsService]
+    }).compile();
+
+    controller = module.get<AccountsController>(AccountsController);
+  });
+
+  it("should be defined", () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/accounts/test/accounts.service.spec.ts
+++ b/src/accounts/test/accounts.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { AccountsService } from "../accounts.service";
+
+describe("AccountsService", () => {
+  let service: AccountsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AccountsService]
+    }).compile();
+
+    service = module.get<AccountsService>(AccountsService);
+  });
+
+  it("should be defined", () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,7 +5,8 @@ import { ConfigModule } from "@nestjs/config";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { configModuleValidationSchema } from "./configs/env-validation.config";
 import { typeOrmModuleAsyncOptions } from "./configs/database.config";
-import { AccountsModule } from './accounts/accounts.module';
+import { AccountsModule } from "./accounts/accounts.module";
+import { UserModule } from "./user/user.module";
 
 @Module({
   imports: [
@@ -14,6 +15,7 @@ import { AccountsModule } from './accounts/accounts.module';
       validationSchema: configModuleValidationSchema
     }),
     TypeOrmModule.forRootAsync(typeOrmModuleAsyncOptions),
+    UserModule,
     AccountsModule
   ],
   controllers: [AppController],

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,7 @@ import { ConfigModule } from "@nestjs/config";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { configModuleValidationSchema } from "./configs/env-validation.config";
 import { typeOrmModuleAsyncOptions } from "./configs/database.config";
+import { AccountsModule } from './accounts/accounts.module';
 
 @Module({
   imports: [
@@ -12,7 +13,8 @@ import { typeOrmModuleAsyncOptions } from "./configs/database.config";
       isGlobal: true,
       validationSchema: configModuleValidationSchema
     }),
-    TypeOrmModule.forRootAsync(typeOrmModuleAsyncOptions)
+    TypeOrmModule.forRootAsync(typeOrmModuleAsyncOptions),
+    AccountsModule
   ],
   controllers: [AppController],
   providers: [AppService]

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,0 +1,31 @@
+import { Module } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { APP_GUARD } from "@nestjs/core";
+import { JwtModule } from "@nestjs/jwt";
+import { PassportModule } from "@nestjs/passport";
+import { UserModule } from "src/user/user.module";
+import { JwtAuthGuard } from "./jwt.auth.guard";
+
+@Module({
+  imports: [
+    PassportModule.register({ defaultStrategy: "jwt", session: false }),
+    JwtModule.registerAsync({
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => ({
+        global: true,
+        secret: config.get<string>("JWT_SECRET_KEY"),
+        signOptions: { expiresIn: "1d" }
+      })
+    }),
+    UserModule
+  ],
+  controllers: [],
+
+  providers: [
+    {
+      provide: APP_GUARD,
+      useClass: JwtAuthGuard
+    }
+  ]
+})
+export class AuthModule {}

--- a/src/auth/jwt.auth.guard.ts
+++ b/src/auth/jwt.auth.guard.ts
@@ -1,0 +1,27 @@
+import { CanActivate, ExecutionContext, Injectable } from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+import { AuthGuard } from "@nestjs/passport";
+
+import { Observable } from "rxjs";
+import { IS_PUBLIC_KEY } from "src/common/decorator/public.decorator";
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard("jwt") implements CanActivate {
+  constructor(private reflector: Reflector) {
+    super();
+  }
+
+  canActivate(context: ExecutionContext): boolean | Promise<boolean> | Observable<boolean> {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass()
+    ]);
+    if (isPublic) {
+      return true;
+    }
+
+    const authenticated = super.canActivate(context);
+
+    return authenticated;
+  }
+}

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -1,0 +1,26 @@
+import _ from "lodash";
+import { ExtractJwt, Strategy } from "passport-jwt";
+import { UserService } from "src/user/user.service";
+
+import { Injectable } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { PassportStrategy } from "@nestjs/passport";
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor(
+    configService: ConfigService,
+    private readonly userService: UserService
+  ) {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      secretOrKey: configService.get("JWT_SECRET")
+    });
+  }
+
+  async validate(payload: any) {
+    const user = await this.userService.findUserById(payload.sub);
+    return user;
+  }
+}

--- a/src/common/decorator/public.decorator.ts
+++ b/src/common/decorator/public.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from "@nestjs/common";
+
+export const IS_PUBLIC_KEY = "isPublic";
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);

--- a/src/common/entities/base.entity.ts
+++ b/src/common/entities/base.entity.ts
@@ -1,0 +1,15 @@
+import { CreateDateColumn, DeleteDateColumn, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
+
+export class BaseEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  @DeleteDateColumn()
+  deletedAt: Date;
+}

--- a/src/common/types/userRole.type.ts
+++ b/src/common/types/userRole.type.ts
@@ -1,0 +1,5 @@
+export const role = {
+  User: "user",
+  Admin: "admin"
+} as const;
+type role = (typeof role)[keyof typeof role]; // 'user' | 'admin'

--- a/src/user/dto/create-user.dto.ts
+++ b/src/user/dto/create-user.dto.ts
@@ -1,79 +1,62 @@
-import { ApiProperty, OmitType, PickType } from "@nestjs/swagger";
-import { IsEmail, IsNotEmpty, IsOptional, IsString, Matches, MinLength } from "class-validator";
+import { IsEmail, IsNotEmpty, IsOptional, IsString, IsStrongPassword } from "class-validator";
 
 // 회원가입
 export class CreateUserDto {
   /**
-
-이메일
-@example "test@test.com"
-@requires true
-*/
+   * 이메일
+   * @example "test@test.com"
+   * @requires true
+   */
   @IsEmail()
   @IsNotEmpty()
   email: string;
 
   /**
-
-비밀번호
-@example "Abcde123"
-@requires true
-*/
+   * 비밀번호
+   * @example "Abcde123!"
+   * @requires true
+   */
   @IsNotEmpty()
   @IsString()
-  @MinLength(4)
+  @IsStrongPassword({ minLength: 8, minUppercase: 1, minNumbers: 1, minSymbols: 1 })
   password: string;
 
   /**
-
-확인 비밀번호
-@example "Abcde123"
-@requires true
-*/
+   * 확인 비밀번호
+   * @example "Abcde123!"
+   * @requires true
+   */
   @IsNotEmpty()
   @IsString()
-  @MinLength(4)
+  @IsStrongPassword({ minLength: 8, minUppercase: 1, minNumbers: 1, minSymbols: 1 })
   passwordCheck: string;
 
   /**
-
-이름
-@example "김민재"
-@requires true
-*/
+   * 이름
+   * @example "김민재"
+   * @requires true
+   */
   @IsString()
   @IsNotEmpty()
   name: string;
 
   /**
-
-닉네임
-@example "주식의왕"
-@requires true
-*/
+   * 닉네임
+   * @example "주식의왕"
+   * @requires true
+   */
   @IsString()
   @IsNotEmpty()
   nickName: string;
 
   /**
-
-핸드폰 번호
-@example "010-1111-1111"
-@requires true
-*/
+   * 핸드폰 번호
+   * @example "010-1111-1111"
+   * @requires true
+   */
   @IsString()
   @IsNotEmpty()
   phone: string;
-
-  /**
-
-가입형태
-@example "uesr"
-@requires true
-*/
-  @IsString()
-  @IsOptional()
-  signupType: string;
 }
 
 // // 로그인

--- a/src/user/dto/create-user.dto.ts
+++ b/src/user/dto/create-user.dto.ts
@@ -18,7 +18,7 @@ export class CreateUserDto {
    */
   @IsNotEmpty()
   @IsString()
-  @IsStrongPassword({ minLength: 8, minUppercase: 1, minNumbers: 1, minSymbols: 1 })
+  @IsStrongPassword({ minLength: 8, minNumbers: 1, minSymbols: 1 })
   password: string;
 
   /**
@@ -28,7 +28,7 @@ export class CreateUserDto {
    */
   @IsNotEmpty()
   @IsString()
-  @IsStrongPassword({ minLength: 8, minUppercase: 1, minNumbers: 1, minSymbols: 1 })
+  @IsStrongPassword({ minLength: 8, minNumbers: 1, minSymbols: 1 })
   passwordCheck: string;
 
   /**

--- a/src/user/dto/update-user.dto.ts
+++ b/src/user/dto/update-user.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from "@nestjs/mapped-types";
+import { CreateUserDto } from "./create-user.dto";
+
+export class UpdateUserDto extends PartialType(CreateUserDto) {}

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -1,4 +1,6 @@
-import { Column, CreateDateColumn, DeleteDateColumn, Entity, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
+import { Account } from "src/accounts/entities/account.entity";
+import { BaseEntity } from "src/common/entities/base.entity";
+import { Column, Entity, OneToMany } from "typeorm";
 
 const role = {
   User: "user",
@@ -9,10 +11,7 @@ type role = (typeof role)[keyof typeof role]; // 'user' | 'admin'
 @Entity({
   name: "users"
 })
-export class User {
-  @PrimaryGeneratedColumn()
-  id: number;
-
+export class User extends BaseEntity {
   @Column({ type: "varchar", nullable: false, unique: true })
   email: string;
 
@@ -28,16 +27,12 @@ export class User {
   @Column({ type: "varchar", nullable: false })
   phone: string;
 
-  @Column({ type: "varchar", nullable: false, default: "user" })
+  @Column({ type: "varchar", nullable: false, default: "local" })
   signupType: string;
 
   @Column({ type: "enum", nullable: false, enum: role, default: role.User })
   role: role;
 
-  @CreateDateColumn()
-  created_at: Date;
-  @UpdateDateColumn()
-  updated_at: Date;
-  @DeleteDateColumn()
-  deleted_at: Date;
+  @OneToMany(() => Account, (account) => account.user, { cascade: ["soft-remove"] })
+  account: Account[];
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -2,8 +2,9 @@ import { Controller, Get, Post, Body, Patch, Param, Delete, BadRequestException 
 import { UserService } from "./user.service";
 import { CreateUserDto } from "./dto/create-user.dto";
 import { UpdateUserDto } from "./dto/update-user.dto";
-import { Public } from "src/common/decorator/public.decorator";
+
 import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
+import { Public } from "src/common/decorator/public.decorator";
 @ApiBearerAuth()
 @ApiTags("User")
 @Controller("user")
@@ -11,15 +12,20 @@ export class UserController {
   constructor(private readonly userService: UserService) {}
 
   /**
-
-회원가입
-@returns
-*/
+   * 회원가입
+   * @param createUserDto
+   * @returns
+   */
   @Public()
   @Post()
-  create(@Body() { email, password, passwordCheck, name, nickName, phone, signupType }: CreateUserDto) {
+  async create(@Body() createUserDto: CreateUserDto) {
+    const { password, passwordCheck } = createUserDto;
     if (password !== passwordCheck) throw new BadRequestException("비밀번호를 확인해주세요.");
-    return this.userService.createUser(email, password, name, nickName, phone, signupType);
+    await this.userService.createUser(createUserDto);
+    return {
+      success: true,
+      message: "okay"
+    };
   }
 
   @Get()

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -1,0 +1,28 @@
+import { Module } from "@nestjs/common";
+import { UserService } from "./user.service";
+import { UserController } from "./user.controller";
+import { PassportModule } from "@nestjs/passport";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { User } from "./entities/user.entity";
+import { JwtModule } from "@nestjs/jwt";
+import { ConfigService } from "@nestjs/config";
+import { JwtStrategy } from "src/auth/jwt.strategy";
+
+@Module({
+  imports: [
+    PassportModule,
+    TypeOrmModule.forFeature([User]),
+    JwtModule.registerAsync({
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => ({
+        global: true,
+        secret: config.get<string>("JWT_SECRET_KEY"),
+        signOptions: { expiresIn: "1d" }
+      })
+    })
+  ],
+  controllers: [UserController],
+  providers: [JwtStrategy, UserService],
+  exports: [UserService]
+})
+export class UserModule {}

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -17,7 +17,9 @@ export class UserService {
     private jwtService: JwtService
   ) {}
 
-  async createUser(email: string, password: string, name: string, nickName: string, phone: string, signupType: string) {
+  async createUser(createUserDto: CreateUserDto) {
+    const { email, password, name, nickName, phone } = createUserDto;
+
     const existUser = await this.findUserByEmail(email);
     if (existUser) throw new ConflictException("이미 존재하는 회원입니다.");
 
@@ -31,8 +33,7 @@ export class UserService {
       password: hashPassword,
       nickName,
       phone,
-      name,
-      signupType
+      name
     });
   }
 


### PR DESCRIPTION
#9 

**진행사항**
1) 계좌 관련 리소스 생성
2) 계좌 생성 API 추가 
3) 유저 테이블과 1:N관계 설정

**특이사항**
1) 머지 후 누락 파일 추가
- 처음 머지 시 추가되었던 파일들이 모두 누락되어 아래 파일들 수기로 추가
- update-user.dto.ts, user.module.ts, userRole.type.ts, public.decorator.ts,jwt.stratege.ts,jwt.auth.guard.ts, auth.module.ts

2) User 관련 코드 수정
1. User entity 
- BaseEntity 적용
- signupType : 가입 방법을 나타내므로 user가 아니라 local로 수정
- Account 엔티티와 1:N 관계설정

2. create-user.dto.ts
- 스웨거 주석 형식 통일
- Password : IsStrongPassword 옵션 적용
- signupType : 가입 형태는 유저가 직접 입력하는 것이 아니기 때문에 삭제

3. user.controller.ts, service.ts 구조분해할당 수정