### PR TITLE
(rank) 랭킹 기능 구현

### DIFF
--- a/assets/css/stock_main.css
+++ b/assets/css/stock_main.css
@@ -37,3 +37,59 @@
 .rank-list-wrap .rank-price span {
   font-size: 12px;
 }
+
+/* 랭킹보드 부분 s */
+.stock-ranking-header h3 {
+  font-weight: bold;
+}
+
+.stock-ranking-header-contents {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+}
+
+.ranking-season {
+  font-weight: bold;
+}
+
+.criteria-date {
+  color: #797979;
+  font-size: 12px;
+}
+
+.stock-ranking-body {
+  background-color: #e8f1fe;
+  height: max-content;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  align-items: center;
+  border-radius: 3rem;
+}
+
+.table {
+  --bs-table-bg: transparent;
+  text-align: center;
+  margin-top: 3rem;
+  margin-bottom: 3rem;
+  width: 90%;
+}
+
+.stock-ranking-discribtion {
+  margin-bottom: 3rem;
+  width: 90%;
+}
+
+.stock-ranking-discribtion h5 {
+  font-weight: bold;
+  font-size: 15px;
+  margin-bottom: 0.5rem;
+}
+
+.stock-ranking-discribtion-contents {
+  display: flex;
+  flex-direction: column;
+  font-size: 12px;
+}
+/* 랭킹보드 부분 e */

--- a/assets/js/account.js
+++ b/assets/js/account.js
@@ -120,7 +120,7 @@ async function modifyAccountName() {
 
 /* DB에 새로 입력된 계좌 이름 업데이트하는 함수 */
 async function updateAccountName(newName, token, accountId) {
-  const apiUrl = apiBaseUrl + `accounts/${accountId}`;
+  const apiUrl = `/api/accounts/${accountId}`;
 
   await axios.patch(apiUrl, { name: newName }, {
     headers: {
@@ -140,7 +140,7 @@ $('.delete-comment-btn').on('click', function () {
 });
 
 async function deleteAccount(accountId) {
-  const apiUrl = apiBaseUrl + `accounts/${accountId}`;
+  const apiUrl = `/api/accounts/${accountId}`;
 
   try {
     await axios.delete(apiUrl, {
@@ -165,7 +165,7 @@ const createAccountBtn = $('#accountCreate')
 createAccountBtn.on('click', async function () {
   const accountName = $('#accountName').val()
 
-  const apiUrl = apiBaseUrl + 'accounts'
+  const apiUrl = '/api/accounts'
 
   try {
     await axios.post(apiUrl, { name: accountName }, {

--- a/assets/js/account.js
+++ b/assets/js/account.js
@@ -2,11 +2,10 @@ import { addComma } from "./common.js";
 import getToken from "./common.js";
 
 const token = getToken()
-const apiBaseUrl = `/api/`
 
 /* 나의 계좌 가져오는 함수 */
 const getMyAccountsByToken = async (token) => {
-  const apiUrl = apiBaseUrl + 'accounts'
+  const apiUrl = '/api/accounts'
 
   try {
     const result = await axios.get(apiUrl, {
@@ -20,16 +19,15 @@ const getMyAccountsByToken = async (token) => {
     const mainDom = document.querySelector(".accounts-list")
 
     if (account) {
-      const { id, name, point, accountNumber, totalStockValue, totalOrderPrice } = account;
+      const { id, name, accountNumber, totalValue } = account;
 
       const baseValue = 100000000
-      const ttlAccountValues = point + totalStockValue + totalOrderPrice
 
-      const profit = ttlAccountValues - baseValue
+      const profit = totalValue - baseValue
       const formatProfit = profit > 0 ? `+${addComma(profit)}` : `${addComma(profit)}`
       const profitPercentage = ((profit / baseValue) * 100).toFixed(1)
 
-      const formatValues = addComma(ttlAccountValues)
+      const formatValues = addComma(totalValue)
 
       let profitClass
 

--- a/assets/js/stock-main.js
+++ b/assets/js/stock-main.js
@@ -1,4 +1,7 @@
 import { addComma } from "/js/common.js";
+import getToken from "./common.js";
+
+const token = getToken()
 
 rankListData();
 
@@ -34,3 +37,61 @@ async function rankListData() {
     console.error("Error:", error.message);
   }
 }
+
+/* 랭킹 데이터 가져오기 */
+
+async function getAccountRank() {
+  const apiUrl = '/api/accounts/rank'
+
+  try {
+    const result = await axios.get(apiUrl, {
+      headers: {
+        'Authorization': token,
+      }
+    })
+
+    const topTenAccounts = result.data.topTenAccounts
+    console.log('topTenAccount: ', topTenAccounts);
+
+    return topTenAccounts
+  } catch (error) {
+    console.error(error);
+    const errorMessage = error.response.data.message;
+    alert(errorMessage);
+  }
+}
+
+async function spreadTopTenAccounts() {
+  const mainDom = document.querySelector('.account-rank-list')
+  const topTenAccounts = await getAccountRank()
+
+  let rank = 0
+
+  mainDom.innerHTML = topTenAccounts
+    .map(account => {
+      const { id, name: accountName, totalValue, accountNumber, user } = account
+
+      const baseValue = 100000000
+      const profit = totalValue - baseValue
+      const formatProfit = profit > 0 ? `${addComma(profit)}` : `${addComma(profit)}`
+      const profitPercentage = ((profit / baseValue) * 100).toFixed(1)
+
+      const formatValues = addComma(totalValue)
+
+      rank += 1
+
+      return `
+      <tr data-id=${id}>
+      <th scope="row">${rank}</th>
+      <td>${user.nickName}</td>
+      <td>${accountName}</td>
+      <td>${accountNumber}</td>
+      <td>${formatProfit} 원</td>
+      <td>${profitPercentage}%</td>
+      <td>${formatValues} 원</td>
+    </tr>
+      `
+    }).join("")
+}
+
+await spreadTopTenAccounts()

--- a/assets/js/stock-myaccount.js
+++ b/assets/js/stock-myaccount.js
@@ -6,7 +6,7 @@ const token = getToken()
 
 /* 나의 계좌 정보 받아오기 */
 export const getMyAccountInfo = async () => {
-  const apiUrl = '/api/accounts'
+  const apiUrl = '/api/accounts/info'
 
   try {
     const result = await axios.get(apiUrl, {

--- a/assets/views/stock_main.html
+++ b/assets/views/stock_main.html
@@ -98,76 +98,15 @@
                     <th scope="col">순위</th>
                     <th scope="col">닉네임</th>
                     <th scope="col">계좌명</th>
+                    <th scope="col">계좌번호</th>
+                    <th scope="col">총 수익</th>
                     <th scope="col">수익률</th>
                     <th scope="col">총 평가 가치</th>
                   </tr>
                 </thead>
-                <tbody>
+                <tbody class="account-rank-list">
                   <tr>
                     <th scope="row">1</th>
-                    <td>천재</td>
-                    <td>천재계좌</td>
-                    <td>10%</td>
-                    <td>100,000,000 원</td>
-                  </tr>
-                  <tr>
-                    <th scope="row">2</th>
-                    <td>천재</td>
-                    <td>천재계좌</td>
-                    <td>10%</td>
-                    <td>100,000,000 원</td>
-                  </tr>
-                  <tr>
-                    <th scope="row">3</th>
-                    <td>천재</td>
-                    <td>천재계좌</td>
-                    <td>10%</td>
-                    <td>100,000,000 원</td>
-                  </tr>
-                  <tr>
-                    <th scope="row">4</th>
-                    <td>천재</td>
-                    <td>천재계좌</td>
-                    <td>10%</td>
-                    <td>100,000,000 원</td>
-                  </tr>
-                  <tr>
-                    <th scope="row">5</th>
-                    <td>천재</td>
-                    <td>천재계좌</td>
-                    <td>10%</td>
-                    <td>100,000,000 원</td>
-                  </tr>
-                  <tr>
-                    <th scope="row">6</th>
-                    <td>천재</td>
-                    <td>천재계좌</td>
-                    <td>10%</td>
-                    <td>100,000,000 원</td>
-                  </tr>
-                  <tr>
-                    <th scope="row">7</th>
-                    <td>천재</td>
-                    <td>천재계좌</td>
-                    <td>10%</td>
-                    <td>100,000,000 원</td>
-                  </tr>
-                  <tr>
-                    <th scope="row">8</th>
-                    <td>천재</td>
-                    <td>천재계좌</td>
-                    <td>10%</td>
-                    <td>100,000,000 원</td>
-                  </tr>
-                  <tr>
-                    <th scope="row">9</th>
-                    <td>천재</td>
-                    <td>천재계좌</td>
-                    <td>10%</td>
-                    <td>100,000,000 원</td>
-                  </tr>
-                  <tr>
-                    <th scope="row">10</th>
                     <td>천재</td>
                     <td>천재계좌</td>
                     <td>10%</td>
@@ -178,10 +117,16 @@
               <div class="stock-ranking-discribtion">
                 <h5>[랭킹 관련 안내사항]</h5>
                 <div class="stock-ranking-discribtion-contents">
-                  <span>* 랭킹은 매일 오전 11시 30분에 업데이트 됩니다.</span>
                   <span
-                    >* 계좌의 총 평가 가치는 보유하신 포인트, 대기 주문 상태의 매수 금액, 현재 보유중인 주식의
-                    평가금액을 합산하였습니다.</span
+                    >* 랭킹은 매일 오전 11시 30분
+                    <span style="color: #eb5665; font-weight: bold">전날 종가 기준으로 업데이트</span>
+                    됩니다.</span
+                  >
+                  <span
+                    >* 계좌의 총 평가 가치는
+                    <span style="font-weight: bold"
+                      >보유하신 포인트, 대기 주문 상태의 매수 금액, 현재 보유중인 주식의 평가금액</span
+                    >을 합산하였습니다.</span
                   >
                 </div>
               </div>

--- a/assets/views/stock_main.html
+++ b/assets/views/stock_main.html
@@ -83,6 +83,111 @@
       <div id="main-content">
         <div id="stock-header"></div>
         <div class="contents-wrap">
+          <div class="stock-ranking-wrap mt-5 mb-5">
+            <div class="stock-ranking-header mb-2">
+              <h3>👑 명예의 전당</h3>
+              <div class="stock-ranking-header-contents mt-3">
+                <span class="ranking-season">* 시즌 1 기간 : 2024.02.01 ~ 28</span>
+                <span class="criteria-date">* 전날 오전 11시 30분 기준</span>
+              </div>
+            </div>
+            <div class="stock-ranking-body">
+              <table class="table table-hover">
+                <thead>
+                  <tr>
+                    <th scope="col">순위</th>
+                    <th scope="col">닉네임</th>
+                    <th scope="col">계좌명</th>
+                    <th scope="col">수익률</th>
+                    <th scope="col">총 평가 가치</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <th scope="row">1</th>
+                    <td>천재</td>
+                    <td>천재계좌</td>
+                    <td>10%</td>
+                    <td>100,000,000 원</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">2</th>
+                    <td>천재</td>
+                    <td>천재계좌</td>
+                    <td>10%</td>
+                    <td>100,000,000 원</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">3</th>
+                    <td>천재</td>
+                    <td>천재계좌</td>
+                    <td>10%</td>
+                    <td>100,000,000 원</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">4</th>
+                    <td>천재</td>
+                    <td>천재계좌</td>
+                    <td>10%</td>
+                    <td>100,000,000 원</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">5</th>
+                    <td>천재</td>
+                    <td>천재계좌</td>
+                    <td>10%</td>
+                    <td>100,000,000 원</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">6</th>
+                    <td>천재</td>
+                    <td>천재계좌</td>
+                    <td>10%</td>
+                    <td>100,000,000 원</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">7</th>
+                    <td>천재</td>
+                    <td>천재계좌</td>
+                    <td>10%</td>
+                    <td>100,000,000 원</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">8</th>
+                    <td>천재</td>
+                    <td>천재계좌</td>
+                    <td>10%</td>
+                    <td>100,000,000 원</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">9</th>
+                    <td>천재</td>
+                    <td>천재계좌</td>
+                    <td>10%</td>
+                    <td>100,000,000 원</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">10</th>
+                    <td>천재</td>
+                    <td>천재계좌</td>
+                    <td>10%</td>
+                    <td>100,000,000 원</td>
+                  </tr>
+                </tbody>
+              </table>
+              <div class="stock-ranking-discribtion">
+                <h5>[랭킹 관련 안내사항]</h5>
+                <div class="stock-ranking-discribtion-contents">
+                  <span>* 랭킹은 매일 오전 11시 30분에 업데이트 됩니다.</span>
+                  <span
+                    >* 계좌의 총 평가 가치는 보유하신 포인트, 대기 주문 상태의 매수 금액, 현재 보유중인 주식의
+                    평가금액을 합산하였습니다.</span
+                  >
+                </div>
+              </div>
+            </div>
+          </div>
+          <hr />
           <div class="account-header">
             <h2 class="board-title">나의 계좌</h2>
             <div class="create-btn-description">

--- a/src/accounts/accounts.controller.ts
+++ b/src/accounts/accounts.controller.ts
@@ -31,17 +31,34 @@ export class AccountsController {
   }
 
   /**
-   * 나의 모든 계좌 조회하기
+   * 나의 계좌 전체 가치 가져오기
+   * @param user
    * @returns
    */
   @Get()
-  async findAllAccount(@UserInfo() user: User) {
-    const accounts = await this.accountsService.findMyAccountById(user.id);
+  async getMyAccountValue(@UserInfo() user: User) {
+    const account: Account = await this.accountsService.getMyAccountValue(user.id);
 
     return {
       success: true,
       message: "okay",
-      data: accounts
+      data: account
+    };
+  }
+
+  /**
+   * 나의 계좌 상세 정보 가져오기
+   * @param user
+   * @returns
+   */
+  @Get("info")
+  async getMyAccountInfo(@UserInfo() user: User) {
+    const account: Account = await this.accountsService.getMyAccountDetailInfo(user.id);
+
+    return {
+      success: true,
+      message: "okay",
+      data: account
     };
   }
 

--- a/src/accounts/accounts.controller.ts
+++ b/src/accounts/accounts.controller.ts
@@ -6,6 +6,7 @@ import { ApiBearerAuth, ApiTags } from "@nestjs/swagger";
 import { UserInfo } from "src/common/decorator/user.decorator";
 import { User } from "src/user/entities/user.entity";
 import { AuthGuard } from "@nestjs/passport";
+import { Account } from "./entities/account.entity";
 // import { JwtAuthGuard } from "src/auth/jwt.auth.guard";
 
 @ApiBearerAuth()
@@ -45,19 +46,17 @@ export class AccountsController {
   }
 
   /**
-   * 나의 특정 계좌 조회하기
-   * @param accountId
-   * @param user
+   * Top 10 랭킹 가져오기
    * @returns
    */
-  @Get("g")
-  async findOne(@UserInfo() user: User) {
-    const account = await this.accountsService.getMyAccountDetailInfo(user.id);
+  @Get("rank")
+  async getRankAccounts() {
+    const topTenAccounts: Account[] = await this.accountsService.getRankAccounts();
 
     return {
       success: true,
       message: "okay",
-      data: account
+      topTenAccounts
     };
   }
 

--- a/src/accounts/accounts.module.ts
+++ b/src/accounts/accounts.module.ts
@@ -3,11 +3,12 @@ import { AccountsService } from "./accounts.service";
 import { AccountsController } from "./accounts.controller";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { Account } from "./entities/account.entity";
+import { SlackService } from "src/common/slack/slack.service";
 
 @Module({
   imports: [TypeOrmModule.forFeature([Account])],
   controllers: [AccountsController],
-  providers: [AccountsService],
+  providers: [AccountsService, SlackService],
   exports: [AccountsService]
 })
 export class AccountsModule {}

--- a/src/accounts/accounts.service.ts
+++ b/src/accounts/accounts.service.ts
@@ -195,8 +195,10 @@ export class AccountsService {
 
   async getRankAccounts(): Promise<Account[]> {
     const topTenAccounts: Account[] = await this.accountRepository
-      .createQueryBuilder()
-      .orderBy("total_value", "DESC")
+      .createQueryBuilder("a")
+      .leftJoinAndSelect("a.user", "u")
+      .select(["a.id", "a.accountNumber", "a.point", "a.totalValue", "a.name", "u.nickName"])
+      .orderBy("a.totalValue", "DESC")
       .take(10)
       .getMany();
 

--- a/src/accounts/accounts.service.ts
+++ b/src/accounts/accounts.service.ts
@@ -66,7 +66,17 @@ export class AccountsService {
     return accountNumber;
   }
 
-  async findMyAccountById(userId: number): Promise<Account> {
+  async getMyAccountValue(userId: number): Promise<Account> {
+    const account: Account = await this.accountRepository
+      .createQueryBuilder()
+      .select(["id", "account_number AS accountNumber", "point", "total_value AS totalValue", "name"])
+      .where("user_id=:userId", { userId })
+      .getRawOne();
+
+    return account;
+  }
+
+  async getMyAccountDetailInfo(userId: number): Promise<Account> {
     const account = await this.accountRepository
       .createQueryBuilder("a")
       .select(["id", "name", "point", "a.accountNumber AS accountNumber"])
@@ -97,30 +107,6 @@ export class AccountsService {
   // 계좌 찾기
   async findOneAccount(userId: number) {
     const account = this.accountRepository.findOne({ where: { userId } });
-    return account;
-  }
-
-  async getMyAccountDetailInfo(userId: number): Promise<Account> {
-    const account: Account = await this.accountRepository
-      .createQueryBuilder("a")
-      .leftJoinAndSelect("a.stockHoldings", "sh")
-      .where("a.userId=:userId", { userId })
-      .select([
-        "a.id",
-        "a.name",
-        "a.point",
-        "a.userId",
-        "a.accountNumber",
-        "sh.stockName",
-        "sh.stockCode",
-        "sh.numbers"
-      ]) // 계좌가 보유한 주식 목록 조인 예정
-      .getOne();
-
-    if (!account) {
-      throw new NotFoundException("해당하는 계좌를 찾을 수 없습니다.");
-    }
-
     return account;
   }
 

--- a/src/accounts/entities/account.entity.ts
+++ b/src/accounts/entities/account.entity.ts
@@ -21,6 +21,9 @@ export class Account extends BaseEntity {
   @Column({ default: 100000000 })
   point: number;
 
+  @Column({ default: 100000000 })
+  totalValue: number;
+
   @IsString()
   @Column({ nullable: false, unique: true })
   accountNumber: string;


### PR DESCRIPTION
**진행사항**
1. API 추가
- 보유한 현금 포인트 + 매수 주문 금액 + 보유한 주식 총 가치
- 모든 유저의 계좌 가치를 계산하여 Account Entity - totalValue 컬럼에 업데이트 (매일 오전 11시30분)

2. 프론트 구현
- 탑 10 랭킹 프론트에 표시
- 계좌 이름 수정 및 삭제 API 요청 URL 수정