### PR TITLE
(order/front) 주문내역 프론트 적용

### DIFF
--- a/assets/css/my-account.css
+++ b/assets/css/my-account.css
@@ -193,3 +193,16 @@
   display: flex;
   flex-direction: row-reverse;
 }
+
+.my-order-btn {
+  position: relative;
+}
+
+.my-order-btn a {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 2;
+}

--- a/assets/css/stock-detail.css
+++ b/assets/css/stock-detail.css
@@ -146,3 +146,68 @@
 .star-stock img:hover {
   cursor: pointer;
 }
+
+/* 내 주식 s */
+.stock-dt-my-order-info-wrap {
+  display: flex;
+  flex-direction: column;
+}
+
+.stock-dt-order-wrap h2 {
+  font-weight: bold;
+}
+
+.my-order-header-top {
+  display: flex;
+  justify-content: space-between;
+}
+
+.my-order-header-top-left {
+  display: flex;
+  flex-direction: column;
+}
+
+.my-order-header-top-right {
+  display: flex;
+  flex-direction: column;
+}
+
+.my-order-total-price-wrap {
+  display: flex;
+  flex-direction: column;
+}
+
+.my-order-header-bottom {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.my-order-header-bottom-left {
+  display: flex;
+  flex-direction: column;
+}
+
+.my-order-header-bottom-right {
+  display: flex;
+  flex-direction: column;
+}
+
+.order-number {
+  font-weight: bold;
+  font-size: 20px;
+}
+
+.ttl-profit {
+  font-size: 14px;
+  text-align: end;
+}
+
+.ttl-profit.red {
+  color: #eb5665;
+}
+
+.ttl-profit.blue {
+  color: #5044fa;
+}
+/* 내 주식 e */

--- a/assets/css/stock-order.css
+++ b/assets/css/stock-order.css
@@ -3,6 +3,7 @@
   align-items: center;
   justify-content: space-between;
   margin-bottom: 1rem;
+  height: 30px;
 }
 
 .parent-category {

--- a/assets/css/stock-order.css
+++ b/assets/css/stock-order.css
@@ -1,0 +1,55 @@
+.order-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.parent-category {
+  margin-right: 2rem;
+  font-weight: bold;
+}
+
+.stock-name {
+  margin-right: 2rem;
+  font-weight: bold;
+}
+
+.order-info {
+  display: flex;
+  text-align: center;
+}
+
+.child-category {
+  margin-right: 2rem;
+}
+
+.stock-name {
+  width: 150px;
+}
+
+.order-ttl-price {
+  width: 150px;
+  margin-right: 1rem;
+}
+
+.order-numbers {
+  font-weight: bold;
+  margin-right: 1rem;
+}
+
+.order-date-btn button {
+  margin-right: 2rem;
+}
+
+.buy {
+  color: #db1515;
+}
+
+.sell {
+  color: #405fff;
+}
+
+.pending {
+  color: #797979;
+}

--- a/assets/js/my-comments.js
+++ b/assets/js/my-comments.js
@@ -35,6 +35,7 @@ const spreadCommentsList = async () => {
         const { id, createdAt, content } = comment
         const { id: titleId, title, commentNumbers } = comment.post
         const dateObject = new Date(createdAt);
+        dateObject.setHours(dateObject.getHours() - 9)
         const formattedDate = `${dateObject.getFullYear()}-${String(dateObject.getMonth() + 1).padStart(2, "0")}-${String(dateObject.getDate()).padStart(2, "0")} ${String(dateObject.getHours()).padStart(2, "0")}:${String(dateObject.getMinutes()).padStart(2, "0")}`;
 
         return `

--- a/assets/js/my-comments.js
+++ b/assets/js/my-comments.js
@@ -62,7 +62,7 @@ const spreadCommentsList = async () => {
       </li>
       `
       }).join("")
-    renderPagination(total, commentsPage, '/views/my-comments.html');
+    renderPagination(total, commentsPage, '/views/my-comments.html?');
   } else {
     mainDom.innerHTML = `
     <div class="none-contents">

--- a/assets/js/my-info.js
+++ b/assets/js/my-info.js
@@ -16,7 +16,10 @@ const getMyInfoByToken = async (token) => {
 
     const { createdAt, email, name, nickName, phone, signupType } = result.data;
 
-    const formattedDate = createdAt.split("T")[0];
+    const dateObject = new Date(createdAt)
+    dateObject.setHours(dateObject.getHours() - 9)
+
+    const formattedDate = dateObject.toISOString().split("T")[0];
 
     const mainDom = document.querySelector(".profile-wrap");
     if (signupType !== "local") {

--- a/assets/js/my-post.js
+++ b/assets/js/my-post.js
@@ -35,7 +35,11 @@ const spreadPostsList = async () => {
     mainDom.innerHTML = posts
       .map(post => {
         const { id, category, title, nickName, createdAt, commentNumbers } = post
-        const formattedDate = createdAt.split("T")[0]
+
+        const dateObject = new Date(createdAt)
+        dateObject.setHours(dateObject.getHours() - 9)
+
+        const formattedDate = dateObject.toISOString().split("T")[0];
 
         const commentClass = commentNumbers === 0 ? "comment hidden" : "comment";
 

--- a/assets/js/my-post.js
+++ b/assets/js/my-post.js
@@ -59,7 +59,7 @@ const spreadPostsList = async () => {
       `
       }).join("")
 
-    renderPagination(total, postsPage, '/views/my-posts.html');
+    renderPagination(total, postsPage, '/views/my-posts.html?');
   } else {
     mainDom.innerHTML = `
     <div class="none-contents">

--- a/assets/js/news-main.js
+++ b/assets/js/news-main.js
@@ -36,7 +36,7 @@ async function fetchNewsData(url) {
       })
       .join("");
 
-    renderPagination(total, newsPage, "/views/news-main.html");
+    renderPagination(total, newsPage, "/views/news-main.html?");
   } catch (error) {
     console.error(error);
     const errorMessage = error.response.data.message;

--- a/assets/js/notice-main.js
+++ b/assets/js/notice-main.js
@@ -29,7 +29,11 @@ const getNoticeData = async () => {
       mainDom.innerHTML = noticeList
         .map((notice) => {
           const { id, title, createdAt } = notice;
-          const formattedDate = createdAt.split("T")[0];
+
+          const dateObject = new Date(createdAt)
+          dateObject.setHours(dateObject.getHours() - 9)
+
+          const formattedDate = dateObject.toISOString().split("T")[0];
 
           return `
         <li class="contents">

--- a/assets/js/notice-main.js
+++ b/assets/js/notice-main.js
@@ -47,7 +47,7 @@ const getNoticeData = async () => {
         `;
         })
         .join("");
-      renderPagination(noticeTotal, noticePage, "/views/notice-main.html");
+      renderPagination(noticeTotal, noticePage, "/views/notice-main.html?");
     }
   } catch (error) {
     console.error(error);

--- a/assets/js/notice-page.js
+++ b/assets/js/notice-page.js
@@ -22,6 +22,8 @@ document.addEventListener("DOMContentLoaded", async () => {
 
         // 날짜 포맷 변경
         const dateObject = new Date(data.createdAt);
+        dateObject.setHours(dateObject.getHours() - 9)
+
         const formattedDate = `${dateObject.getFullYear()}
         -${String(dateObject.getMonth() + 1).padStart(2, "0")}
         -${String(dateObject.getDate()).padStart(2, "0")}

--- a/assets/js/pagenation.js
+++ b/assets/js/pagenation.js
@@ -16,10 +16,10 @@ export default function renderPagination(_totalCount, currentPage, url) {
   const fragmentPage = document.createDocumentFragment();
   if (prev > 0) {
     let allpreli = document.createElement('li');
-    allpreli.insertAdjacentHTML("beforeend", `<a href='${url}?page=1' id='allprev' class="arrow">《</a>`);
+    allpreli.insertAdjacentHTML("beforeend", `<a href='${url}page=1' id='allprev' class="arrow">《</a>`);
 
     let preli = document.createElement('li');
-    preli.insertAdjacentHTML("beforeend", `<a href='${url}?page=${Number(page) - 1}' id='prev' class="arrow">〈</a>`);
+    preli.insertAdjacentHTML("beforeend", `<a href='${url}page=${Number(page) - 1}' id='prev' class="arrow">〈</a>`);
 
     fragmentPage.appendChild(allpreli);
     fragmentPage.appendChild(preli);
@@ -27,16 +27,16 @@ export default function renderPagination(_totalCount, currentPage, url) {
 
   for (let i = first; i <= last; i++) {
     const li = document.createElement("li");
-    li.insertAdjacentHTML("beforeend", `<a href='${url}?page=${i}' id='page-${i}' data-num='${i}'>${i}</a>`);
+    li.insertAdjacentHTML("beforeend", `<a href='${url}page=${i}' id='page-${i}' data-num='${i}'>${i}</a>`);
     fragmentPage.appendChild(li);
   }
 
   if (last < totalPage) {
     let allendli = document.createElement('li');
-    allendli.insertAdjacentHTML("beforeend", `<a href='${url}?page=${totalPage}'  id='allnext' class="arrow">》</a>`);
+    allendli.insertAdjacentHTML("beforeend", `<a href='${url}page=${totalPage}'  id='allnext' class="arrow">》</a>`);
 
     let endli = document.createElement('li');
-    endli.insertAdjacentHTML("beforeend", `<a  href='${url}?page=${Number(page) + 1}'  id='next' class="arrow">〉</a>`);
+    endli.insertAdjacentHTML("beforeend", `<a  href='${url}page=${Number(page) + 1}'  id='next' class="arrow">〉</a>`);
 
     fragmentPage.appendChild(endli);
     fragmentPage.appendChild(allendli);

--- a/assets/js/post-read.js
+++ b/assets/js/post-read.js
@@ -21,6 +21,7 @@ async function fetchPostData(postId) {
     const commentsResponse = await axios.get(`/api/comments/post/${postId}`);
     const comments = commentsResponse.data.data;
     const createdAt = new Date(data.createdAt);
+    createdAt.setHours(createdAt.getHours() - 9)
     const formattedCreatedAt = `${createdAt.getFullYear()}-${String(createdAt.getMonth() + 1).padStart(2, "0")}-${String(createdAt.getDate()).padStart(2, "0")} ${String(createdAt.getHours()).padStart(2, "0")}:${String(createdAt.getMinutes()).padStart(2, "0")}`;
 
     postBox.innerHTML = `
@@ -53,6 +54,7 @@ async function fetchPostData(postId) {
         const { id: dataId, createdAt, content } = comment;
         const { nickName, id: userId } = comment.commentUser;
         const dateObject = new Date(createdAt);
+        dateObject.setHours(dateObject.getHours() - 9)
         const formattedDate = `${dateObject.getFullYear()}-${String(dateObject.getMonth() + 1).padStart(2, "0")}-${String(dateObject.getDate()).padStart(2, "0")} ${String(dateObject.getHours()).padStart(2, "0")}:${String(dateObject.getMinutes()).padStart(2, "0")}`;
 
         return `

--- a/assets/js/post.js
+++ b/assets/js/post.js
@@ -63,7 +63,7 @@ async function fetchPostData(url) {
       })
       .join("");
 
-    renderPagination(total, postPage, "/views/post.html");
+    renderPagination(total, postPage, "/views/post.html?");
   } catch (error) {
     console.error(error);
     const errorMessage = error.response.data.message;

--- a/assets/js/post.js
+++ b/assets/js/post.js
@@ -41,6 +41,7 @@ async function fetchPostData(url) {
         const { nickName, title, commentNumbers, category, createdAt, id } = post;
         const commentClass = commentNumbers === 0 ? "comment hidden" : "comment";
         const dateObject = new Date(createdAt);
+        dateObject.setHours(dateObject.getHours() - 9)
         const formattedDate = `${dateObject.getFullYear()}-${String(dateObject.getMonth() + 1).padStart(2, "0")}-${String(dateObject.getDate()).padStart(2, "0")} ${String(dateObject.getHours()).padStart(2, "0")}:${String(dateObject.getMinutes()).padStart(2, "0")}`;
         return `
       <li class="contents">

--- a/assets/js/push-noti.js
+++ b/assets/js/push-noti.js
@@ -51,6 +51,7 @@ export async function spreadMyAllPushNotis() {
         const readStatusClass = isRead === false ? "unread" : "read";
 
         const dateObject = new Date(createdAt);
+        dateObject.setHours(dateObject.getHours() - 9)
         const formattedDate = `${dateObject.getFullYear()}-${String(dateObject.getMonth() + 1).padStart(2, "0")}-${String(dateObject.getDate()).padStart(2, "0")} ${String(dateObject.getHours()).padStart(2, "0")}:${String(dateObject.getMinutes()).padStart(2, "0")}`;
 
         let message

--- a/assets/js/stock-detail.js
+++ b/assets/js/stock-detail.js
@@ -1,6 +1,7 @@
 import io from 'https://cdn.socket.io/4.7.4/socket.io.esm.min.js';
 import { addComma } from "/js/common.js";
 import getToken from './common.js';
+import renderPagination from '/js/pagenation.js'
 
 const params = new URLSearchParams(window.location.search);
 const trKey = params.get("code");
@@ -299,6 +300,291 @@ async function deleteStarStock() {
   }
 }
 
+async function switchMyStockInfo() {
+  $('.stock-dt-cont-wrap').hide()
+
+  await spreadOrderLists()
+}
+
 $('.star-stock-on').on('click', async function () {
   await deleteStarStock()
 })
+
+/* 해당 보유 주식 정보 가져오기 */
+async function getMyOrderInfo() {
+  const apiUrl = `/api/order/stock/${trKey}`
+
+  try {
+    const result = await axios.get(apiUrl, {
+      headers: {
+        'Authorization': token,
+      }
+    })
+
+    const myStock = result.data.data
+
+    return myStock
+
+  } catch (error) {
+    console.error(error)
+    const errorMessage = error.response.data.message;
+    alert(errorMessage);
+  }
+}
+
+/* 보유 주식 정보 뿌리기 */
+async function spreadMyOrderInfo() {
+  const mainDom = document.querySelector('.stock-dt-my-order-info-wrap')
+  const myStockInfo = await getMyOrderInfo()
+
+  if (myStockInfo) {
+    const { clpr, numbers, stockCode, stockName, totalCompleteBuyOrderNumbers, totalCompleteBuyOrderPrice } = myStockInfo
+
+    const averageBuyValues = Math.ceil(totalCompleteBuyOrderPrice / totalCompleteBuyOrderNumbers) // 1주 구매 평균 단가
+    const formatAvgBuyVal = addComma(averageBuyValues)
+
+    const originValues = averageBuyValues * numbers // 투자 원금 (1주 평균 구매단가 * 현재 보유 주식 수)]
+    const formatOriginValues = addComma(originValues)
+
+    const ttlStockPrice = clpr * numbers
+    const formatTtlPrice = addComma(ttlStockPrice)
+
+    const profit = ttlStockPrice - originValues
+    const formatProfit = profit > 0 ? `+${addComma(profit)}` : `${addComma(profit)}`
+
+    const profitPercent = ((profit / originValues) * 100).toFixed(1)
+    const formatNumbers = addComma(numbers)
+
+    let profitClass
+
+    if (profit > 0) {
+      profitClass = 'red'
+    } else if (profit < 0) {
+      profitClass = 'blue'
+    }
+
+    mainDom.innerHTML = `
+    <h2>보유 주식</h2>
+    <div class="my-order-header-wrap mt-2">
+      <div class="my-order-header-top">
+        <div class="my-order-header-top-left">
+          <span>1주 평균 금액</span>
+          <span class="order-number">${formatAvgBuyVal} 원</span>
+        </div>
+        <div class="my-order-header-top-right">
+          <span>총 평가 금액</span>
+          <div class="my-order-total-price-wrap">
+            <span class="order-number">${formatTtlPrice} 원</span>
+            <span class="ttl-profit ${profitClass}">${formatProfit} (${profitPercent}%)</span>
+          </div>
+        </div>
+      </div>
+      <div class="my-order-header-bottom mt-4">
+        <div class="my-order-header-bottom-left">
+          <span>보유수량</span>
+          <span class="order-number">${formatNumbers} 주</span>
+        </div>
+        <div class="my-order-header-bottom-right">
+          <span>투자 원금</span>
+          <div class="my-order-total-price-wrap">
+            <span class="order-number">${formatOriginValues} 원</span>
+          </div>
+        </div>
+      </div>
+    </div>
+    `
+  } else {
+    mainDom.innerHTML = `
+    <h2>보유 주식</h2>
+    <div class="none-contents">
+      <span>보유 주식이 없습니다.</span>
+    </div>
+    `
+  }
+}
+
+await spreadMyOrderInfo()
+
+const ordersPage = params.get("page")
+
+/* 해당 주식 주문내역 가져오기 */
+const getMyOrders = async () => {
+  const apiUrl = `/api/order/order/${trKey}?page=${ordersPage}`
+  try {
+    const result = await axios.get(apiUrl, {
+      headers: {
+        'Authorization': token,
+      }
+    })
+
+    const ordersLists = result.data.data.orders
+    const ordersTotal = result.data.data.total
+
+    return {
+      ordersLists,
+      ordersTotal
+    }
+
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+/* 주문 내역 뿌리기 */
+const spreadOrderLists = async () => {
+  const mainDom = document.querySelector('.order-list')
+  const { ordersLists, ordersTotal } = await getMyOrders()
+  console.log('ordersLists: ', ordersLists);
+
+  if (ordersLists.length !== 0) {
+    mainDom.innerHTML = ordersLists
+      .map(order => {
+        const {
+          buySell,
+          id,
+          orderNumbers,
+          status,
+          stockName,
+          ttlPrice,
+          updatedAt
+        } = order
+
+        const formatTtlPrice = addComma(ttlPrice)
+        const formatOrderNumbers = addComma(orderNumbers)
+        const formatDate = updatedAt.split("T")[0]
+
+        let categoryClass
+        let orderCategory
+        let childCategory
+        let cancelButtonDisplay
+        let buyCancelClass
+
+        if (buySell === true && status === "complete") {
+          categoryClass = "buy";
+          orderCategory = "구매";
+          childCategory = "구매";
+          cancelButtonDisplay = "none"
+        } else if (buySell === false && status === "complete") {
+          categoryClass = "sell";
+          orderCategory = "판매";
+          childCategory = "판매";
+          cancelButtonDisplay = "none"
+        } else if (buySell === true && status === "cancel") {
+          categoryClass = "pending";
+          orderCategory = "취소";
+          childCategory = "구매";
+          cancelButtonDisplay = "none"
+        } else if (buySell === false && status === "cancel") {
+          categoryClass = "pending";
+          orderCategory = "취소";
+          childCategory = "판매";
+          cancelButtonDisplay = "none"
+        } else if (buySell === true && status === "order") {
+          orderCategory = "대기";
+          childCategory = "구매";
+        } else if (buySell === false && status === "order") {
+          orderCategory = "대기";
+          childCategory = "판매";
+        }
+
+        return `
+            <li data-id=${id}>
+              <div class="order-info">
+                <span class="parent-category ${categoryClass}">${orderCategory}</span>
+                <span class="stock-name">${stockName}</span>
+                <span class="order-ttl-price">${formatTtlPrice} 원</span>
+                <span class="order-numbers ${categoryClass}">${formatOrderNumbers} 주</span>
+                <span class="child-category ${categoryClass}">${childCategory}</span>
+              </div>
+              <div class="order-date-btn">
+              <button class="hm-button hm-sub-color" style="display:${cancelButtonDisplay}">취소하기</button>
+                <span>${formatDate}</span>
+              </div>
+            </li>
+        `
+      }).join("")
+    renderPagination(ordersTotal, ordersPage, `/views/stock-detail.html?code=${trKey}&name=${trName}&`);
+  } else {
+    mainDom.innerHTML = `
+    <div class="none-contents">
+      <span>주문 내역이 없습니다.</span>
+    </div>
+    `
+  }
+}
+
+await spreadOrderLists()
+
+const popupDom = document.querySelector('.delete-order-chk')
+
+/* 대기 주문 취소 확인 팝업 생성 */
+$('.order-date-btn button').on('click', function () {
+  drPopupOpen('.delete-order-chk')
+
+  const orderId = $(this).closest('li').attr('data-id');
+  console.log('orderId: ', orderId);
+  const orderCategory = $(this).closest('li').find('.child-category').text();
+  const orderStockName = $(this).closest('li').find('.stock-name').text();
+  const orderTtlPrice = $(this).closest('li').find('.order-ttl-price').text();
+  const orderNumbers = $(this).closest('li').find('.order-numbers').text();
+
+  const buttonId = orderCategory === "구매" ? "cancel-buy-order" : "cancel-sell-order"
+
+  popupDom.innerHTML = `
+  <header>
+  <h1>대기 주문 취소</h1>
+</header>
+<div class="hm-popup-content">
+  <p class="mt-2" style="color: #eb5665">대기 주문내역은 복구할 수 없습니다.</p>
+  <p>그래도 취소하시겠습니까?</p>
+  <p class="mt-2" style="color: #eb5665; font-weight:bold"> ${orderStockName} ${orderNumbers} ${orderTtlPrice} ${orderCategory}
+</div>
+<footer>
+  <div class="d-flex justify-content-between hm-bg-white">
+    <a href="#none" class="hm-button me-2 hm-gray-color" onclick="drPopupClose(this)">돌아가기</a>
+    <a href="#none" class="hm-button ms-2" id=${buttonId} onclick="drPopupClose(this)">취소하기</a>
+  </div>
+</footer>
+  `
+
+  $('#cancel-buy-order').on('click', function () {
+    cancelPendingBuyOrder(orderId)
+  })
+
+  $('#cancel-sell-order').on('click', function () {
+    cancelPendingSellOrder(orderId)
+  })
+
+});
+
+async function cancelPendingBuyOrder(orderId) {
+  const apiUrl = `/api/order/wait/buy/${orderId}`;
+  try {
+    await axios.patch(apiUrl, {}, {
+      headers: {
+        'Authorization': token,
+      }
+    });
+    window.location.reload();
+  } catch (error) {
+    console.error(error);
+    const errorMessage = error.response.data.message;
+    alert(errorMessage);
+  }
+}
+
+async function cancelPendingSellOrder(orderId) {
+  const apiUrl = `/api/order/wait/sell/${orderId}`;
+  try {
+    await axios.patch(apiUrl, {}, {
+      headers: {
+        'Authorization': token,
+      }
+    });
+    window.location.reload();
+  } catch (error) {
+    console.error(error);
+    const errorMessage = error.response.data.message;
+    alert(errorMessage);
+  }
+}

--- a/assets/js/stock-main.js
+++ b/assets/js/stock-main.js
@@ -21,7 +21,7 @@ async function rankListData() {
         const priceClass = parseFloat(list.prdy_ctrt) < 0 ? percentClass : "";
         return `
             <li>
-              <a href='/views/stock-detail.html?code=${list.mksc_shrn_iscd}&name=${list.hts_kor_isnm}'></a>
+              <a href='/views/stock-detail.html?code=${list.mksc_shrn_iscd}&name=${list.hts_kor_isnm}&page=1'></a>
               <div class="rank-name">
                 <p><span>${list.data_rank}</span> ${list.hts_kor_isnm}</p>
               </div>

--- a/assets/js/stock-main.js
+++ b/assets/js/stock-main.js
@@ -67,6 +67,8 @@ async function spreadTopTenAccounts() {
 
   /* 랭킹 기준 날짜 보여주기 */
   const updateDate = new Date(topTenAccounts[0].updatedAt)
+  updateDate.setHours(updateDate.getHours() - 9); // 한국 시간으로 변환하기 위해 9시간을 빼줍니다.
+
   const koreanTime = `${updateDate.getFullYear()}-${String(updateDate.getMonth() + 1).padStart(2, "0")}-${String(updateDate.getDate()).padStart(2, "0")} ${String(updateDate.getHours()).padStart(2, "0")}:${String(updateDate.getMinutes()).padStart(2, "0")}`;
 
   $('.criteria-date').text(`* ${koreanTime} 기준`)

--- a/assets/js/stock-myaccount.js
+++ b/assets/js/stock-myaccount.js
@@ -85,6 +85,7 @@ export const spreadMyAccountInfo = async () => {
     <span class="my-account-roi ${profitClass}"> ${formatProfit} 원 (${profitPercentage}%)</span>
   </div>
   <div class="my-order-btn">
+    <a href="stock-order.html?page=1"></a>
     <button class="hm-button">주문내역 보기</button>
   </div>
 </div>

--- a/assets/js/stock-myaccount.js
+++ b/assets/js/stock-myaccount.js
@@ -167,7 +167,7 @@ export const spreadMyStocks = async () => {
 
         return `
         <li data-id=${id}>
-        <a href="/views/stock-detail.html?code=${stockCode}&name=${stockName}"></a>
+        <a href="/views/stock-detail.html?code=${stockCode}&name=${stockName}&page=1"></a>
         <div class="my-stock-name-box">
           <div class="name-code">
             <div class="stock-name">${stockName}</div>
@@ -229,7 +229,7 @@ export const spreadStarStocks = async () => {
 
         return `
         <li data-id=${id}>
-        <a href="/views/stock-detail.html?code=${srtnCd}&name=${itmsNm}"></a>
+        <a href="/views/stock-detail.html?code=${srtnCd}&name=${itmsNm}&page=1"></a>
         <div class="stock-name-box">
           <div class="market">${mrktCtg}</div>
           <div class="name-code">

--- a/assets/js/stock-order.js
+++ b/assets/js/stock-order.js
@@ -1,0 +1,188 @@
+import { addComma, drPopupOpen } from "./common.js";
+import getToken from "./common.js"
+import renderPagination from '/js/pagenation.js'
+
+const token = getToken();
+const params = new URLSearchParams(window.location.search)
+const ordersPage = params.get("page")
+
+/* 전체 주문내역 가져오기 */
+const getMyOrders = async () => {
+  const apiUrl = `/api/order/order?page=${ordersPage}`
+  try {
+    const result = await axios.get(apiUrl, {
+      headers: {
+        'Authorization': token,
+      }
+    })
+
+    const ordersLists = result.data.orders
+    const ordersTotal = result.data.total
+
+    return {
+      ordersLists,
+      ordersTotal
+    }
+
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+const spreadOrderLists = async () => {
+  const mainDom = document.querySelector('.order-list')
+  const { ordersLists, ordersTotal } = await getMyOrders()
+
+  if (ordersLists.length !== 0) {
+    mainDom.innerHTML = ordersLists
+      .map(order => {
+        const {
+          buySell,
+          id,
+          orderNumbers,
+          status,
+          stockName,
+          ttlPrice,
+          updatedAt
+        } = order
+
+        const formatTtlPrice = addComma(ttlPrice)
+        const formatOrderNumbers = addComma(orderNumbers)
+        const formatDate = updatedAt.split("T")[0]
+
+        let categoryClass
+        let orderCategory
+        let childCategory
+        let cancelButtonDisplay
+        let buyCancelClass
+
+        if (buySell === true && status === "complete") {
+          categoryClass = "buy";
+          orderCategory = "구매";
+          childCategory = "구매";
+          cancelButtonDisplay = "none"
+        } else if (buySell === false && status === "complete") {
+          categoryClass = "sell";
+          orderCategory = "판매";
+          childCategory = "판매";
+          cancelButtonDisplay = "none"
+        } else if (buySell === true && status === "cancel") {
+          categoryClass = "pending";
+          orderCategory = "취소";
+          childCategory = "구매";
+          cancelButtonDisplay = "none"
+        } else if (buySell === false && status === "cancel") {
+          categoryClass = "pending";
+          orderCategory = "취소";
+          childCategory = "판매";
+          cancelButtonDisplay = "none"
+        } else if (buySell === true && status === "order") {
+          orderCategory = "대기";
+          childCategory = "구매";
+        } else if (buySell === false && status === "order") {
+          orderCategory = "대기";
+          childCategory = "판매";
+        }
+
+        return `
+            <li data-id=${id}>
+              <div class="order-info">
+                <span class="parent-category ${categoryClass}">${orderCategory}</span>
+                <span class="stock-name">${stockName}</span>
+                <span class="order-ttl-price">${formatTtlPrice} 원</span>
+                <span class="order-numbers ${categoryClass}">${formatOrderNumbers} 주</span>
+                <span class="child-category ${categoryClass}">${childCategory}</span>
+              </div>
+              <div class="order-date-btn">
+              <button class="hm-button hm-sub-color" style="display:${cancelButtonDisplay}">취소하기</button>
+                <span>${formatDate}</span>
+              </div>
+            </li>
+        `
+      }).join("")
+    renderPagination(ordersTotal, ordersPage, '/views/stock-order.html');
+  } else {
+    mainDom.innerHTML = `
+    <div class="none-contents">
+      <span>주문 내역이 없습니다.</span>
+    </div>
+    `
+  }
+}
+
+await spreadOrderLists()
+
+
+const popupDom = document.querySelector('.delete-order-chk')
+
+/* 대기 주문 취소 확인 팝업 생성 */
+$('.order-date-btn button').on('click', function () {
+  drPopupOpen('.delete-order-chk')
+
+  const orderId = $(this).closest('li').attr('data-id');
+  console.log('orderId: ', orderId);
+  const orderCategory = $(this).closest('li').find('.child-category').text();
+  const orderStockName = $(this).closest('li').find('.stock-name').text();
+  const orderTtlPrice = $(this).closest('li').find('.order-ttl-price').text();
+  const orderNumbers = $(this).closest('li').find('.order-numbers').text();
+
+  const buttonId = orderCategory === "구매" ? "cancel-buy-order" : "cancel-sell-order"
+
+  popupDom.innerHTML = `
+  <header>
+  <h1>대기 주문 취소</h1>
+</header>
+<div class="hm-popup-content">
+  <p class="mt-2" style="color: #eb5665">대기 주문내역은 복구할 수 없습니다.</p>
+  <p>그래도 취소하시겠습니까?</p>
+  <p class="mt-2" style="color: #eb5665; font-weight:bold"> ${orderStockName} ${orderNumbers} ${orderTtlPrice} ${orderCategory}
+</div>
+<footer>
+  <div class="d-flex justify-content-between hm-bg-white">
+    <a href="#none" class="hm-button me-2 hm-gray-color" onclick="drPopupClose(this)">돌아가기</a>
+    <a href="#none" class="hm-button ms-2" id=${buttonId} onclick="drPopupClose(this)">취소하기</a>
+  </div>
+</footer>
+  `
+
+  $('#cancel-buy-order').on('click', function () {
+    cancelPendingBuyOrder(orderId)
+  })
+
+  $('#cancel-sell-order').on('click', function () {
+    cancelPendingSellOrder(orderId)
+  })
+
+});
+
+async function cancelPendingBuyOrder(orderId) {
+  const apiUrl = `/api/order/wait/buy/${orderId}`;
+  try {
+    await axios.patch(apiUrl, {}, {
+      headers: {
+        'Authorization': token,
+      }
+    });
+    window.location.reload();
+  } catch (error) {
+    console.error(error);
+    const errorMessage = error.response.data.message;
+    alert(errorMessage);
+  }
+}
+
+async function cancelPendingSellOrder(orderId) {
+  const apiUrl = `/api/order/wait/sell/${orderId}`;
+  try {
+    await axios.patch(apiUrl, {}, {
+      headers: {
+        'Authorization': token,
+      }
+    });
+    window.location.reload();
+  } catch (error) {
+    console.error(error);
+    const errorMessage = error.response.data.message;
+    alert(errorMessage);
+  }
+}

--- a/assets/js/stock-order.js
+++ b/assets/js/stock-order.js
@@ -100,7 +100,7 @@ const spreadOrderLists = async () => {
             </li>
         `
       }).join("")
-    renderPagination(ordersTotal, ordersPage, '/views/stock-order.html');
+    renderPagination(ordersTotal, ordersPage, '/views/stock-order.html?');
   } else {
     mainDom.innerHTML = `
     <div class="none-contents">

--- a/assets/js/stock-search.js
+++ b/assets/js/stock-search.js
@@ -30,7 +30,7 @@ export const getSearchData = async (keyword) => {
 
         return `
       <li>
-        <a href="/views/stock-detail.html?code=${stockCode}&name=${stockName}"></a>
+        <a href="/views/stock-detail.html?code=${stockCode}&name=${stockName}&page=1"></a>
         <div class="stock-name-box">
           <div class="market">${market}</div>
           <div class="name-code">

--- a/assets/js/twit/twit-detail.js
+++ b/assets/js/twit/twit-detail.js
@@ -26,6 +26,7 @@ async function getDetailTwitData(url) {
     const { senderName, receiverName, createdAt, contents, isRead } = item;
     const mainDom = document.querySelector("#twitDetailWrap");
     const dateObject = new Date(createdAt);
+    dateObject.setHours(dateObject.getHours() - 9)
     const formattedDate = `${dateObject.getFullYear()}-${String(dateObject.getMonth() + 1).padStart(2, "0")}-${String(dateObject.getDate()).padStart(2, "0")} ${String(dateObject.getHours()).padStart(2, "0")}:${String(dateObject.getMinutes()).padStart(2, "0")}`;
 
     mainDom.innerHTML = `

--- a/assets/js/twit/twit.js
+++ b/assets/js/twit/twit.js
@@ -56,7 +56,7 @@ async function getTwitData(url) {
         `
       }).join("");
 
-    pageUrl ? renderPagination(total, twit_page, '/views/twit/receive-twit.html') : renderPagination(total, twit_page, '/views/twit/twit.html');
+    pageUrl ? renderPagination(total, twit_page, '/views/twit/receive-twit.html?') : renderPagination(total, twit_page, '/views/twit/twit.html?');
   } catch (error) {
     alert(error.response.data.message);
     console.error(error);

--- a/assets/js/twit/twit.js
+++ b/assets/js/twit/twit.js
@@ -40,6 +40,7 @@ async function getTwitData(url) {
         console.log('receive', receiverName, 'send', senderName)
         const send = url === `/api/twits/getReceive?page=${twit_page}` ? false : true;
         const dateObject = new Date(createdAt);
+        dateObject.setHours(dateObject.getHours() - 9)
         const formattedDate = `${dateObject.getFullYear()}-${String(dateObject.getMonth() + 1).padStart(2, "0")}-${String(dateObject.getDate()).padStart(2, "0")} ${String(dateObject.getHours()).padStart(2, "0")}:${String(dateObject.getMinutes()).padStart(2, "0")}`;
         return `
         <li class="contents">

--- a/assets/views/main.html
+++ b/assets/views/main.html
@@ -48,7 +48,7 @@
             </div>
           </li>
           <li>
-            <a href="#none"></a>
+            <a href="/views/news-main.html?page=1"></a>
             <p class="fw-bold fs-6">증권 소식 확인하기</p>
             <div class="img-wrap">
               <img class="h-100" src="/images/banner/contents_3.png" alt="" />

--- a/assets/views/stock-detail.html
+++ b/assets/views/stock-detail.html
@@ -13,9 +13,15 @@
     <link rel="stylesheet" href="/css/bootstrap.min.css" />
     <link rel="stylesheet" href="/css/common.css" />
     <link rel="stylesheet" href="/css/stock-detail.css" />
+    <link rel="stylesheet" href="/css/stock-order.css" />
     <title>HappyMoney</title>
   </head>
   <body>
+    <!-- 삭제 확인 팝업 s -->
+    <div class="hm-dim" onclick="drPopupClose(this)"></div>
+    <div class="hm-popup-wrap delete-order-chk"></div>
+    <!-- 삭제 확인 팝업 e -->
+
     <div class="hm-container">
       <header id="header_wrap"></header>
       <div id="main-content">
@@ -33,10 +39,10 @@
             </div>
             <div class="stock-dt-tit-box mt-3">
               <div class="price"></div>
-              <div class="tab-button-wrap">
-                <button class="hm-button fw-bold me-3">호가</button>
-                <button class="hm-button hm-gray-color fw-bold">내 주식</button>
-              </div>
+              <!-- <div class="tab-button-wrap">
+                <button class="hm-button fw-bold me-3" id="stock-price-button">호가</button>
+                <button class="hm-button hm-gray-color fw-bold" id="my-stock-button">내 주식</button>
+              </div> -->
             </div>
           </div>
           <div class="stock-dt-cont-wrap">
@@ -169,7 +175,15 @@
               </div>
             </div>
           </div>
+          <div class="stock-dt-order-wrap mt-5">
+            <div class="stock-dt-my-order-info-wrap"></div>
+            <div class="stock-dt-my-order-list mt-5">
+              <h2>주문 내역</h2>
+              <ul class="order-list mt-3"></ul>
+            </div>
+          </div>
         </div>
+        <ul id="hm-pagination"></ul>
       </div>
       <footer id="footer_wrap"></footer>
     </div>

--- a/assets/views/stock-order.html
+++ b/assets/views/stock-order.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script type="module" src="/js/jquery-3.7.1.min.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+    <script type="module" src="https://cdn.socket.io/4.7.4/socket.io.esm.min.js"></script>
+    <script type="module" src="/js/bootstrap.min.js"></script>
+    <script type="module" src="/js/common.js"></script>
+    <script type="module" src="/js/stock-common.js"></script>
+    <script type="module" src="/js/stock-order.js"></script>
+    <link rel="stylesheet" href="/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="/css/common.css" />
+    <link rel="stylesheet" href="/css/stock_main.css" />
+    <link rel="stylesheet" href="/css/stock-order.css" />
+    <title>HappyMoney</title>
+  </head>
+  <body>
+    <!-- 삭제 확인 팝업 s -->
+    <div class="hm-dim" onclick="drPopupClose(this)"></div>
+    <div class="hm-popup-wrap delete-order-chk"></div>
+    <!-- 삭제 확인 팝업 e -->
+
+    <div class="hm-container">
+      <header id="header_wrap"></header>
+      <div class="w-100">
+        <article class="hm-banner-two py-5">
+          <div class="hm-banner-width">
+            <div class="img-wrap">
+              <img src="/images/banner/contents_5.png" alt="" />
+            </div>
+            <div class="hm-main-txt text-white text-end">
+              <h2 class="fw-bold">매 시즌 랭킹 시스템으로 재미있게!</h2>
+              <p class="mt-5 fs-6">가상 계좌를 만들어 부담없이 투자해보세요 !</p>
+              <p class="fs-6">수익률과 수익액을 기준으로 매 시즌 TOP 10을 선발합니다.</p>
+              <p class="mt-5 fs-5 fw-bold">[시즌 1 절찬 진행중]</p>
+              <p class="fs-5 fw-bold">2024.02.01 ~ 02.20</p>
+            </div>
+          </div>
+        </article>
+      </div>
+      <div id="main-content">
+        <div id="stock-header"></div>
+        <div class="contents-wrap">
+          <div class="account-header">
+            <h2 class="board-title">총 주문내역</h2>
+          </div>
+          <ul class="order-list"></ul>
+        </div>
+      </div>
+      <ul id="hm-pagination"></ul>
+    </div>
+    <footer id="footer_wrap"></footer>
+  </body>
+</html>

--- a/src/order/order.controller.ts
+++ b/src/order/order.controller.ts
@@ -91,7 +91,7 @@ export class OrderController {
    * @param id
    * @returns
    */
-  @Patch("wait/buy:id")
+  @Patch("wait/buy/:id")
   async cancelBuyOrder(@Param("id") orderId: number, @UserInfo() user: User) {
     const data = await this.orderService.cancelBuyOrder(orderId, user);
 

--- a/src/order/order.controller.ts
+++ b/src/order/order.controller.ts
@@ -134,13 +134,14 @@ export class OrderController {
   }
 
   /**
-   * 보유 주식 상세
-   * @param id
+   * 특정 종목 보유 주식
+   * @param stockCode
+   * @param user
    * @returns
    */
-  @Get("stock/:id")
-  async getStockHolding(@Param("id") stockHoldingId: number, @UserInfo() user: User) {
-    const data = await this.orderService.getStockHolding(stockHoldingId, user);
+  @Get("stock/:stockCode")
+  async getStockHolding(@Param("stockCode") stockCode: string, @UserInfo() user: User) {
+    const data = await this.orderService.getStockHolding(stockCode, user);
 
     return {
       success: true,

--- a/src/order/order.service.ts
+++ b/src/order/order.service.ts
@@ -449,14 +449,47 @@ export class OrderService implements OnModuleInit {
   }
 
   // 해당 주식 조회API
-  async getStockHolding(stockHoldingId: number, { id }: User) {
+  async getStockHolding(stockCode: string, { id }: User) {
     const account = await this.accountsService.findOneAccount(id);
     if (!account) throw new BadRequestException({ success: false, message: "계좌를 생성해주세요." });
 
-    const data = await this.stockHoldingRepository.findOne({
-      where: { id: stockHoldingId, userId: id, accountId: account.id }
-    });
-    if (!data) throw new NotFoundException({ success: false, message: "해당 주식을 찾을 수 없습니다." });
+    // const data = await this.stockHoldingRepository.findOne({
+    //   where: { id: stockHoldingId, userId: id, accountId: account.id }
+    // });
+    // if (!data) throw new NotFoundException({ success: false, message: "해당 주식을 찾을 수 없습니다." });
+
+    const data = await this.stockHoldingRepository
+      .createQueryBuilder("sh")
+      .leftJoinAndSelect("sh.stock", "s")
+      .select([
+        "sh.id AS id",
+        "sh.stockName AS stockName",
+        "sh.userId AS userId",
+        "sh.stockCode AS stockCode",
+        "sh.numbers AS numbers",
+        "s.clpr as clpr"
+      ])
+      .addSelect((subQuery) => {
+        return subQuery
+          .select("SUM(o.order_numbers)", "totalBuyOrderNumbers")
+          .from("orders", "o")
+          .where("o.accountId =:accountId", { accountId: account.id })
+          .andWhere("o.buySell=1")
+          .andWhere("o.status='complete'")
+          .andWhere("o.stockCode=sh.stockCode");
+      }, "totalCompleteBuyOrderNumbers")
+      .addSelect((subQuery) => {
+        return subQuery
+          .select("SUM(o.ttl_price)", "totalBuyOrderPrice")
+          .from("orders", "o")
+          .where("o.accountId =:accountId", { accountId: account.id })
+          .andWhere("o.buySell=1")
+          .andWhere("o.status='complete'")
+          .andWhere("o.stockCode=sh.stockCode");
+      }, "totalCompleteBuyOrderPrice")
+      .where("sh.userId=:userId", { userId: id })
+      .andWhere("sh.stockCode=:stockCode", { stockCode })
+      .getRawOne();
 
     return data;
   }

--- a/src/stock/stock.service.ts
+++ b/src/stock/stock.service.ts
@@ -202,7 +202,7 @@ export class StockService {
     }
   }
 
-  @Cron("30 10 11 * * 1-5") // 공공데이터 업데이트 시간 확인 (월-금 오전 11시 1회 업데이트)
+  @Cron("0 0 11 * * 1-5") // 공공데이터 업데이트 시간 확인 (월-금 오전 11시 1회 업데이트)
   async updateStockAndRank() {
     // 전일 기준 종목 시가총액, 발행주 수, 종가 업데이트
     await this.saveStocks();

--- a/src/stock/stock.service.ts
+++ b/src/stock/stock.service.ts
@@ -202,7 +202,7 @@ export class StockService {
     }
   }
 
-  @Cron("0 0 11 * * 2-6") // 공공데이터 업데이트 시간 확인 (월-금 오전 11시 1회 업데이트)
+  @Cron("30 10 11 * * 1-5") // 공공데이터 업데이트 시간 확인 (월-금 오전 11시 1회 업데이트)
   async updateStockAndRank() {
     // 전일 기준 종목 시가총액, 발행주 수, 종가 업데이트
     await this.saveStocks();


### PR DESCRIPTION
**진행 내역**
1. 전체 주문내역 페이지 생성 
2. 주식 상세페이지 내 주문 내역 추가

**특이사항**
- 주식 상세페이지 내에 페이지네이션 구현을 위해 url로직 수정

> allpreli.insertAdjacentHTML("beforeend", `<a href='${url}page=1' id='allprev' class="arrow"></a>`);

기존 코드의 경우 renderPagination 함수에서 ?page=1로 명시하고 있어서 종목 상세페이지에서는 적용이 불가했음 

url에서 ?를 붙여서 전달하여 해결
(주식 상세페이지에서는 이미 code, name을 param으로 사용하고 있어 ? 가 아닌 &를 붙여야 했음)