### PR TITLE
(user/prontend) 회원탈퇴 후 재가입 방지 / 회원가입 후 뒤로가기 제거

### DIFF
--- a/assets/js/signout-email-verify.js
+++ b/assets/js/signout-email-verify.js
@@ -17,7 +17,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     );
 
     if (response.data.success) {
-      alert("[happymoney] 정상적으로 회원탈퇴 되었습니다.");
+      alert("[happymoney] 정상적으로 회원탈퇴 되었습니다. 재가입이 불가능합니다.");
       window.close();
     } else {
       alert("이메일 인증이 실패했습니다.");

--- a/assets/js/signout.js
+++ b/assets/js/signout.js
@@ -35,7 +35,7 @@ async function signout() {
 
 const signoutBtn = document.getElementById("signoutBtn");
 signoutBtn.addEventListener("click", () => {
-  const userConfirmed = window.confirm("정말로 회원탈퇴 하시겠습니까?");
+  const userConfirmed = window.confirm("정말로 회원탈퇴 하시겠습니까? 재가입이 불가능합니다.");
   if (userConfirmed) {
     signout();
   }

--- a/assets/js/signup.js
+++ b/assets/js/signup.js
@@ -191,6 +191,7 @@ signupBtn.addEventListener("click", async () => {
     if (response.data.success) {
       alert("이메일 인증 후 로그인 해주세요.");
       window.location.href = "/views/main.html";
+      window.history.replaceState(null, null, "/views/main.html");
     } else {
       const errorMessage = response.data.message;
       alert(errorMessage);

--- a/assets/js/signup.js
+++ b/assets/js/signup.js
@@ -46,7 +46,7 @@ emailCheckBtn.addEventListener("click", async () => {
       return;
     }
   } catch (error) {
-    console.error("Error:", error.response);
+    console.error("Error:", error);
   }
 });
 

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -46,7 +46,7 @@ export class UserService {
         <div class="img-wrap">
         <img src="https://cdn.discordapp.com/attachments/1201496380292726794/1201497252355645460/02.png?ex=65ca0883&is=65b79383&hm=296a93e633af34f5f453112e8e87ab08918fadfdfcd068ced4811d08b943d371&" style="width: 300px; height: 300px;" />
         </div>
-        [HAPPYMONEY] 회원가입: <a href="http://localhost:3000/views/signin-email-verify.html?email=${encodeURIComponent(
+        [HAPPYMONEY] 회원가입: <a href="https//happymoneynow.com/views/signin-email-verify.html?email=${encodeURIComponent(
           email
         )}&token=${encodeURIComponent(emailVerifyToken)}">인증하기</a>`
       };
@@ -116,7 +116,7 @@ export class UserService {
         <div class="img-wrap">
         <img src="https://cdn.discordapp.com/attachments/1201496380292726794/1201497252355645460/02.png?ex=65ca0883&is=65b79383&hm=296a93e633af34f5f453112e8e87ab08918fadfdfcd068ced4811d08b943d371&" style="width: 300px; height: 300px;" />
         </div>
-        [HAPPYMONEY] 회원탈퇴: <a href="http://localhost:3000/views/signout-email-verify.html?email=${encodeURIComponent(
+        [HAPPYMONEY] 회원탈퇴: <a href="https://happymoneynow.com/views/signout-email-verify.html?email=${encodeURIComponent(
           user.email
         )}&token=${encodeURIComponent(user.emailVerifyToken)}">인증하기</a>`
       };

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -46,7 +46,7 @@ export class UserService {
         <div class="img-wrap">
         <img src="https://cdn.discordapp.com/attachments/1201496380292726794/1201497252355645460/02.png?ex=65ca0883&is=65b79383&hm=296a93e633af34f5f453112e8e87ab08918fadfdfcd068ced4811d08b943d371&" style="width: 300px; height: 300px;" />
         </div>
-        [HAPPYMONEY] 회원가입: <a href="https://happymoneynow.com/views/signin-email-verify.html?email=${encodeURIComponent(
+        [HAPPYMONEY] 회원가입: <a href="http://localhost:3000/views/signin-email-verify.html?email=${encodeURIComponent(
           email
         )}&token=${encodeURIComponent(emailVerifyToken)}">인증하기</a>`
       };
@@ -116,7 +116,7 @@ export class UserService {
         <div class="img-wrap">
         <img src="https://cdn.discordapp.com/attachments/1201496380292726794/1201497252355645460/02.png?ex=65ca0883&is=65b79383&hm=296a93e633af34f5f453112e8e87ab08918fadfdfcd068ced4811d08b943d371&" style="width: 300px; height: 300px;" />
         </div>
-        [HAPPYMONEY] 회원탈퇴: <a href="https://happymoneynow.com/views/signout-email-verify.html?email=${encodeURIComponent(
+        [HAPPYMONEY] 회원탈퇴: <a href="http://localhost:3000/views/signout-email-verify.html?email=${encodeURIComponent(
           user.email
         )}&token=${encodeURIComponent(user.emailVerifyToken)}">인증하기</a>`
       };
@@ -145,7 +145,7 @@ export class UserService {
 
   async find() {
     return await this.userRepository.find({
-      select: ["id", "email", "name", "deletedAt"],
+      select: ["id", "email", "name", "deletedAt", "nickName"],
       withDeleted: true // soft delete된 항목도 포함
     });
   }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -46,7 +46,7 @@ export class UserService {
         <div class="img-wrap">
         <img src="https://cdn.discordapp.com/attachments/1201496380292726794/1201497252355645460/02.png?ex=65ca0883&is=65b79383&hm=296a93e633af34f5f453112e8e87ab08918fadfdfcd068ced4811d08b943d371&" style="width: 300px; height: 300px;" />
         </div>
-        [HAPPYMONEY] 회원가입: <a href="https//happymoneynow.com/views/signin-email-verify.html?email=${encodeURIComponent(
+        [HAPPYMONEY] 회원가입: <a href="https://happymoneynow.com/views/signin-email-verify.html?email=${encodeURIComponent(
           email
         )}&token=${encodeURIComponent(emailVerifyToken)}">인증하기</a>`
       };

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -2,7 +2,7 @@ import { Injectable, NotFoundException, UnauthorizedException } from "@nestjs/co
 import { CreateUserDto } from "./dto/create-user.dto";
 import { JwtService } from "@nestjs/jwt";
 import { ConfigService } from "@nestjs/config";
-import { Repository } from "typeorm";
+import { IsNull, Not, Repository } from "typeorm";
 import { InjectRepository } from "@nestjs/typeorm";
 import { compareSync, hashSync } from "bcrypt";
 import { User } from "./entities/user.entity";
@@ -144,7 +144,10 @@ export class UserService {
   }
 
   async find() {
-    return await this.userRepository.find();
+    return await this.userRepository.find({
+      select: ["id", "email", "name", "deletedAt"],
+      withDeleted: true // soft delete된 항목도 포함
+    });
   }
 
   async findUserById(id: number) {


### PR DESCRIPTION
* 진행사항
1) 회원탈퇴 후 같은 이메일로 가입하려고 하면, 이메일 인증 됐다는 알림이 뜨지만 이메일 전송은 되지 않음
    재가입이 불가능하도록 설정
2) 회원가입 후 뒤로가기 해서 같은 닉네임으로 가입 돼서 회원가입 후 메인페이지로 넘어가면 뒤로가기 안 되게 수정