### PR TITLE
(bug/fix) 대기 주문 체결 시 푸시 알림 추가

### DIFF
--- a/assets/js/push-noti.js
+++ b/assets/js/push-noti.js
@@ -45,7 +45,7 @@ export async function spreadMyAllPushNotis() {
   if (pushNotis.length !== 0) {
     mainDom.innerHTML =
       pushNotis.map(noti => {
-        const { id, createdAt, serviceType, isRead, contents1, contents2, contentId } = noti
+        const { id, createdAt, serviceType, isRead, contents1, contents2, contents3, contentId } = noti
 
         const readStatus = isRead === false ? "안읽음" : "읽음";
         const readStatusClass = isRead === false ? "unread" : "read";
@@ -67,7 +67,8 @@ export async function spreadMyAllPushNotis() {
             break
 
           case "주식":
-            message = `주식 ${contents1}에 성공하였습니다.`
+            message = `[${contents2}] 주문이 체결되었습니다.`
+            contentUrl = `/views/stock-detail-my.html?code=${contents3[0]}&name=${contents3[1]}&page=1`
             break
         }
 

--- a/src/order/order.module.ts
+++ b/src/order/order.module.ts
@@ -9,6 +9,7 @@ import { StockModule } from "src/stock/stock.module";
 import { BullModule } from "@nestjs/bull";
 import { orderProcessor } from "./order.processor";
 import { ConfigModule, ConfigService } from "@nestjs/config";
+import { PushModule } from "@/push/push.module";
 
 @Module({
   imports: [
@@ -29,7 +30,8 @@ import { ConfigModule, ConfigService } from "@nestjs/config";
     }),
     BullModule.registerQueue({
       name: "orders"
-    })
+    }),
+    PushModule
   ],
   controllers: [OrderController],
   providers: [OrderService, orderProcessor]

--- a/src/push/entities/push.entity.ts
+++ b/src/push/entities/push.entity.ts
@@ -28,6 +28,9 @@ export class Push extends BaseEntity {
   @Column({ nullable: true, comment: "쪽지 발신자 등 사용자에게 보내줄 알림 내용 데이터2" })
   contents2: string;
 
+  @Column({ type: "simple-array", nullable: true, comment: "주식 이름, 코드", default: null })
+  contents3?: any[];
+
   @Column({ nullable: false, comment: "클릭 시 넘어갈 주소에 사용될 Id값" })
   contentId: number;
 


### PR DESCRIPTION
1) 대기 주문 체결(구매/판매) 시 알림 테이블에 데이터 추가
- 알림창에서 해당 종목 주문내역으로 보내기 위해 컬럼 추가

2) 대기 주문 체결(구매/판매) 시 웹 푸시 알림 추가